### PR TITLE
Fix key not found ':money_in_with_card_id_result'

### DIFF
--- a/lib/lemonway/client.rb
+++ b/lib/lemonway/client.rb
@@ -36,7 +36,7 @@ module Lemonway
 
     def client_call method_name, message_opts = {}, client_opts = {}, &block
       resp = @instance.call method_name, client_opts.update(message: build_message(message_opts)), &block
-      result  = resp.body.fetch(:"#{method_name}_response").fetch(:"#{method_name}_result")
+      result = resp.body.fetch(:"#{method_name}_response").fetch(result(method_name))
 
       result = with_custom_parser_options { Hash.from_xml(result) } unless result.is_a? Hash
       result = result.underscore_keys(true).with_indifferent_access
@@ -84,7 +84,12 @@ module Lemonway
       opts
     end
 
+    def result(method_name)
+      if method_name == :money_in_with_card_id
+        "money_in_result"
+      else
+        "#{method_name}_result"
+      end.to_sym
+    end
   end
-
 end
-

--- a/lib/lemonway/version.rb
+++ b/lib/lemonway/version.rb
@@ -1,4 +1,3 @@
 module Lemonway
-  VERSION = "1.0.1"
-
+  VERSION = "1.0.2"
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -63,6 +63,19 @@ describe Lemonway::Client do
         expect(resp[:lwid]).to eq "836"
       end
     end
+
+    it '#money_in_with_card_id' do
+      money_in_opts = method_opts.merge({ card_id: '27', amount_tot: '3.14'})
+
+      expect(subject.instance).to receive(:operations).and_return([:money_in_with_card_id])
+      expect(subject.instance).to receive(:call).with(:money_in_with_card_id, {:message => opts.update(money_in_opts).camelize_keys}).and_call_original
+      VCR.use_cassette("money_in_with_card_id_success") do
+        resp = subject.money_in_with_card_id money_in_opts
+        expect(resp[:rec]).to eq "1234567"
+        expect(resp[:cred]).to eq "3.14"
+        expect(resp[:status]).to eq "3"
+      end
+    end
   end
 
 end


### PR DESCRIPTION
It is a patch for the next error when I try do a money_in_with_card_id:

``` ruby
Lemonway::Client::Error: key not found: :money_in_with_card_id_result, expected `money_in_with_card_id_response.money_in_with_card_id_result` but got : {:money_in_with_card_id_response=>{:money_in_result=>{:e=>{:error=>nil, :code=>"248", :msg=>"Wrong IP format", :prio=>"2"}}, :@xmlns=>"Service_mb_xml"}}
    from /app/lib/lemonway/client.rb:56:in `rescue in client_call'
    from /app/lib/lemonway/client.rb:38:in `client_call'
    from /app/lib/lemonway/client.rb:29:in `method_missing'
    from (irb):20
    from /usr/local/bin/irb:11:in `<main>'

```

I do not have permission to use the test configuration

``` ruby
   {
       : WlLogin => "test"
       : WlPass => "test"
       : Language => "fr"
       : Version => "1.0"
       : Channel => "W"
       : WalletIp => "91.222.286.32"
       : Wsdl => "https://ws.lemonway.fr/mb/ioio/dev/directkit/service.asmx?wsdl"
     }
```

So I used my sandbox config in my local code to create test for the patch. So I have not added the cassete fixture to pull request.

I would like to have access to the configuration of the tests for future contributions I can do.

Thank you very much, a greeting!
